### PR TITLE
Adding ShellOut Functionality 

### DIFF
--- a/daemon_runner.gemspec
+++ b/daemon_runner.gemspec
@@ -27,6 +27,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
 
   spec.add_dependency "logging", "~> 2.1"
+  spec.add_dependency "mixlib-shellout", "~> 2.2"
 
   spec.add_development_dependency "bundler", "~> 1.12"
   spec.add_development_dependency "rake", "~> 10.0"

--- a/lib/daemon_runner.rb
+++ b/lib/daemon_runner.rb
@@ -1,2 +1,3 @@
 require_relative 'daemon_runner/version'
 require_relative 'daemon_runner/client'
+require_relative 'daemon_runner/shell_out'

--- a/lib/daemon_runner/shell_out.rb
+++ b/lib/daemon_runner/shell_out.rb
@@ -1,0 +1,27 @@
+require 'mixlib/shellout'
+
+module DaemonRunner
+  class ShellOut
+    attr_reader :runner, :stdout
+
+    def cwd
+      '/tmp'
+    end
+
+    def timeout
+      15
+    end
+
+    def runner
+      @runner ||= Mixlib::ShellOut.new(command, :cwd => cwd, :timeout => timeout)
+    end
+
+    def run!
+      runner
+      @runner.run_command
+      @runner.error!
+      @stdout = @runner.stdout
+      @runner
+    end
+  end
+end

--- a/lib/daemon_runner/shell_out.rb
+++ b/lib/daemon_runner/shell_out.rb
@@ -3,20 +3,35 @@ require 'mixlib/shellout'
 module DaemonRunner
   class ShellOut
     attr_reader :runner, :stdout
-    attr_reader :command, :cwd, :timeout
+    attr_reader :command, :cwd, :timeout, :wait
 
     # @param command [String] the command to run
     # @param cwd [String] the working directory to run the command
-    # @param timeout [FixNum] the command timeout
-    def initialize(command: nil, cwd: '/tmp', timeout: 15)
+    # @param timeout [Fixnum] the command timeout
+    # @param wait [Boolean] wheather to wait for the command to finish
+    def initialize(command: nil, cwd: '/tmp', timeout: 15, wait: true)
       @command = command
       @cwd = cwd
       @timeout = timeout
+      @wait = wait
     end
 
     # Run command
-    # @return [Mixlib::ShellOut] client
+    # @return [Mixlib::ShellOut, Fixnum] mixlib shellout client or a pid depending on the value of {#wait}
     def run!
+      validate_command
+      if wait
+        run_and_wait
+      else
+        run_and_detach
+      end
+    end
+
+    private
+
+    # Run a command and wait for it to finish
+    # @return [Mixlib::ShellOut] client
+    def run_and_wait
       validate_args
       runner
       @runner.run_command
@@ -25,16 +40,27 @@ module DaemonRunner
       @runner
     end
 
-    private
+    # Run a command in a new process group, thus ignoring any furthur
+    # updates about the status of the process
+    # @return [Fixnum] process id
+    def run_and_detach
+      log_r, log_w = IO.pipe
+      Process.spawn(command, pgroup: true, err: :out, out: log_w)
+      log_r.close
+      log_w.close
+    end
 
-    # @private
-    # Validate arguments before trying to start the command
+    # Validate command is defined before trying to start the command
     # @ raise [ArgumentError] if any of the arguments are missing
-    def validate_args
+    def validate_command
       if @command.nil? && !respond_to?(:command)
         raise ArgumentError, 'Must pass a command or implement a command method'
       end
+    end
 
+    # Validate arguments before trying to start the command
+    # @ raise [ArgumentError] if any of the arguments are missing
+    def validate_args
       if @cwd.nil? && !respond_to?(:cwd)
         raise ArgumentError, 'Must pass a cwd or implement a cwd method'
       end
@@ -44,13 +70,10 @@ module DaemonRunner
       end
     end
 
-    # @private
     # Setup a new Mixlib::ShellOut client runner
     # @return [Mixlib::ShellOut] client
     def runner
       @runner ||= Mixlib::ShellOut.new(command, :cwd => cwd, :timeout => timeout)
     end
-
-
   end
 end

--- a/lib/daemon_runner/shell_out.rb
+++ b/lib/daemon_runner/shell_out.rb
@@ -3,25 +3,54 @@ require 'mixlib/shellout'
 module DaemonRunner
   class ShellOut
     attr_reader :runner, :stdout
+    attr_reader :command, :cwd, :timeout
 
-    def cwd
-      '/tmp'
+    # @param command [String] the command to run
+    # @param cwd [String] the working directory to run the command
+    # @param timeout [FixNum] the command timeout
+    def initialize(command: nil, cwd: '/tmp', timeout: 15)
+      @command = command
+      @cwd = cwd
+      @timeout = timeout
     end
 
-    def timeout
-      15
-    end
-
-    def runner
-      @runner ||= Mixlib::ShellOut.new(command, :cwd => cwd, :timeout => timeout)
-    end
-
+    # Run command
+    # @return [Mixlib::ShellOut] client
     def run!
+      validate_args
       runner
       @runner.run_command
       @runner.error!
       @stdout = @runner.stdout
       @runner
     end
+
+    private
+
+    # @private
+    # Validate arguments before trying to start the command
+    # @ raise [ArgumentError] if any of the arguments are missing
+    def validate_args
+      if @command.nil? && !respond_to?(:command)
+        raise ArgumentError, 'Must pass a command or implement a command method'
+      end
+
+      if @cwd.nil? && !respond_to?(:cwd)
+        raise ArgumentError, 'Must pass a cwd or implement a cwd method'
+      end
+
+      if @timeout.nil? && !respond_to?(:timeout)
+        raise ArgumentError, 'Must pass a timeout or implement a timeout method'
+      end
+    end
+
+    # @private
+    # Setup a new Mixlib::ShellOut client runner
+    # @return [Mixlib::ShellOut] client
+    def runner
+      @runner ||= Mixlib::ShellOut.new(command, :cwd => cwd, :timeout => timeout)
+    end
+
+
   end
 end

--- a/lib/daemon_runner/version.rb
+++ b/lib/daemon_runner/version.rb
@@ -1,3 +1,3 @@
 module DaemonRunner
-  VERSION = '0.1.1'
+  VERSION = '0.2.0'
 end

--- a/test/daemon_runner/shell_out_test.rb
+++ b/test/daemon_runner/shell_out_test.rb
@@ -50,4 +50,19 @@ class ShellOutTest < Minitest::Test
     @cmd.run!
     assert_equal 150, @cmd.timeout
   end
+
+  def test_can_run_new_nowait
+    @cmd = ::DaemonRunner::ShellOut.new(command: 'ping -c 10 localhost',
+                                        cwd: '/tmp',
+                                        timeout: 250,
+                                        wait: false)
+    @cmd.run!
+    assert_equal false, @cmd.wait
+  end
+
+  def test_can_run_wait
+    @cmd = ::TestShellOut.new
+    @cmd.run!
+    assert_equal true, @cmd.wait
+  end
 end

--- a/test/daemon_runner/shell_out_test.rb
+++ b/test/daemon_runner/shell_out_test.rb
@@ -1,0 +1,53 @@
+require 'test_helper'
+
+class TestShellOut < ::DaemonRunner::ShellOut
+  def command
+    'echo 1'
+  end
+
+  def cwd
+    '/'
+  end
+
+  def timeout
+    150
+  end
+end
+
+class ShellOutTest < Minitest::Test
+  def test_can_run_new_command
+    @cmd = ::DaemonRunner::ShellOut.new(command: 'echo 2')
+    @cmd.run!
+    assert_equal '2', @cmd.stdout.chomp
+  end
+
+  def test_can_run_command
+    @cmd = ::TestShellOut.new
+    @cmd.run!
+    assert_equal '1', @cmd.stdout.chomp
+  end
+
+  def test_can_run_new_cwd
+    @cmd = ::DaemonRunner::ShellOut.new(command: 'echo 2', cwd: '/home')
+    @cmd.run!
+    assert_equal '/home', @cmd.cwd
+  end
+
+  def test_can_run_cwd
+    @cmd = ::TestShellOut.new
+    @cmd.run!
+    assert_equal '/', @cmd.cwd
+  end
+
+  def test_can_run_new_timeout
+    @cmd = ::DaemonRunner::ShellOut.new(command: 'echo 2', cwd: '/tmp', timeout: 250)
+    @cmd.run!
+    assert_equal 250, @cmd.timeout
+  end
+
+  def test_can_run_timeout
+    @cmd = ::TestShellOut.new
+    @cmd.run!
+    assert_equal 150, @cmd.timeout
+  end
+end


### PR DESCRIPTION
Adding ShellOut Wrapper that should make running shell commands in tasks a bit easier.

This supports both commands that should block until they are finished and commands that should just be started and forgotten about.