### PR TITLE
Feature: Thorfile for versioning

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,3 +2,8 @@ source 'https://rubygems.org'
 
 # Specify your gem's dependencies in daemon_runner.gemspec
 gemspec
+
+group :development do
+  gem 'bundler', '~> 1.7'
+  gem 'thor-scmversion', '= 1.7.0'
+end

--- a/Thorfile
+++ b/Thorfile
@@ -1,0 +1,5 @@
+# encoding: utf-8
+
+require 'bundler'
+require 'bundler/setup'
+require 'thor/scmversion'


### PR DESCRIPTION
This adds a Thorfile with the [thor-scmversion](https://github.com/RiotGamesMinions/thor-scmversion) plugin to make it easier to bump version numbers as part of a CI job.