### PR TITLE
Add logic to retry errors

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,6 +148,20 @@ def schedule
 end
 ```
 
+### Retries
+Simple interface to retry requests that are known to fails sometimes.  To add a retry wrap the code like this:
+
+```
+DaemonRunner::RetryErrors.retry do
+  my_not_so_good_network_service_that_fails_sometimes
+end
+```
+
+* `options` - Options hash to pass to `retry` (**optional**)
+    * :retries - Number of times to retry an exception (**optional**, _default_: 3)
+    * :exceptions - Array of exceptions to catch and retry (**optional**, _default_: `[Faraday::ClientError]`)
+
+
 ## Development
 
 After checking out the repo, run `bin/setup` to install dependencies. Then, run `rake test` to run the tests. You can also run `bin/console` for an interactive prompt that will allow you to experiment.

--- a/daemon_runner.gemspec
+++ b/daemon_runner.gemspec
@@ -22,6 +22,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency "mixlib-shellout", "~> 2.2"
   spec.add_dependency "diplomat", "~> 1.0"
   spec.add_dependency "rufus-scheduler", "~> 3.2"
+  spec.add_dependency "retryable", "~> 2.0"
 
   spec.add_development_dependency "bundler", "~> 1.12"
   spec.add_development_dependency "rake", "~> 10.0"

--- a/lib/daemon_runner.rb
+++ b/lib/daemon_runner.rb
@@ -1,5 +1,6 @@
 require_relative 'daemon_runner/version'
 require_relative 'daemon_runner/logger'
+require_relative 'daemon_runner/retry_errors'
 require_relative 'daemon_runner/client'
 require_relative 'daemon_runner/shell_out'
 require_relative 'daemon_runner/session'

--- a/lib/daemon_runner/retry_errors.rb
+++ b/lib/daemon_runner/retry_errors.rb
@@ -1,0 +1,18 @@
+require 'retryable'
+
+module DaemonRunner
+    #
+    # Retry Errors
+    #
+    class RetryErrors
+      class << self
+        def retry(retries: 3, exceptions: [Faraday::ClientError], &block)
+          Retryable.retryable({
+            on: exceptions,
+            sleep: lambda { |c| Kernel.sleep(2 ** retries * 0.3) }},
+            &block
+          )
+        end
+      end
+    end
+  end

--- a/lib/daemon_runner/retry_errors.rb
+++ b/lib/daemon_runner/retry_errors.rb
@@ -9,9 +9,10 @@ module DaemonRunner
         def retry(retries: 3, exceptions: [Faraday::ClientError], &block)
           Retryable.retryable({
             on: exceptions,
-            sleep: lambda { |c| Kernel.sleep(2 ** retries * 0.3) }},
-            &block
-          )
+            sleep: lambda { |c| 2 ** c * 0.3 },
+            tries: retries}) do |retries, exception|
+              block.call
+          end
         end
       end
     end

--- a/lib/daemon_runner/retry_errors.rb
+++ b/lib/daemon_runner/retry_errors.rb
@@ -5,12 +5,15 @@ module DaemonRunner
     # Retry Errors
     #
     class RetryErrors
+      extend Logger
+
       class << self
         def retry(retries: 3, exceptions: [Faraday::ClientError], &block)
           Retryable.retryable({
             on: exceptions,
             sleep: lambda { |c| 2 ** c * 0.3 },
             tries: retries}) do |retries, exception|
+              logger.warn "try #{retries} failed with exception: #{exception}" if retries > 0
               block.call
           end
         end

--- a/lib/daemon_runner/retry_errors.rb
+++ b/lib/daemon_runner/retry_errors.rb
@@ -9,12 +9,14 @@ module DaemonRunner
 
       class << self
         def retry(retries: 3, exceptions: [Faraday::ClientError], &block)
-          Retryable.retryable({
+          properties = {
             on: exceptions,
-            sleep: lambda { |c| 2 ** c * 0.3 },
-            tries: retries}) do |retries, exception|
-              logger.warn "try #{retries} failed with exception: #{exception}" if retries > 0
-              block.call
+            sleep: lambda { |c| 2**c * 0.3 },
+            tries: retries
+          }
+          Retryable.retryable(properties) do |retries, exception|
+            logger.warn "try #{retries} failed with exception: #{exception}" if retries > 0
+            block.call
           end
         end
       end

--- a/test/daemon_runner/retry_errors_test.rb
+++ b/test/daemon_runner/retry_errors_test.rb
@@ -1,0 +1,35 @@
+require_relative '../test_helper'
+
+class MyFakeException < ArgumentError; end
+class AnotherFakeException < ArgumentError; end
+
+class RetryErrorsTest < Minitest::Test
+
+  def test_can_pass
+
+    retries = 1
+    test = Proc.new {
+      DaemonRunner::RetryErrors.retry(retries: 7, exceptions: [AnotherFakeException]) do
+        loop do
+          retries += 1
+          if retries % 5 == 0
+            return 0
+          else
+            raise AnotherFakeException
+          end
+        end
+      end
+    }
+    assert_equal(test.call, 0)
+  end
+
+  def test_can_raise_exception
+    assert_raises(MyFakeException) {
+      DaemonRunner::RetryErrors.retry(exceptions: [MyFakeException]) do
+        loop do
+          raise MyFakeException, 'boom'
+        end
+      end
+    }
+  end
+end


### PR DESCRIPTION
This change add a retry decorator that can be added to requests that might fail.  The usage is something like this:

```ruby
DaemonRunner::RetryErrors.retry(exceptions: [RuntimeError]) do
  loop do
    raise RuntimeError, 'boom' if rand * 100 > 90
  end
end
```

After the default of 3 retries it will give up.