### PR TITLE
Fix: DaemonRunner::ShellOut#run! returns pid

### DIFF
--- a/lib/daemon_runner/shell_out.rb
+++ b/lib/daemon_runner/shell_out.rb
@@ -45,9 +45,10 @@ module DaemonRunner
     # @return [Fixnum] process id
     def run_and_detach
       log_r, log_w = IO.pipe
-      Process.spawn(command, pgroup: true, err: :out, out: log_w)
+      pid = Process.spawn(command, pgroup: true, err: :out, out: log_w)
       log_r.close
       log_w.close
+      pid
     end
 
     # Validate command is defined before trying to start the command

--- a/test/daemon_runner/shell_out_test.rb
+++ b/test/daemon_runner/shell_out_test.rb
@@ -65,4 +65,13 @@ class ShellOutTest < Minitest::Test
     @cmd.run!
     assert_equal true, @cmd.wait
   end
+
+  def test_returns_pid_for_nowait
+    @cmd = ::DaemonRunner::ShellOut.new(command: 'ping -c 10 localhost',
+                                        cwd: '/tmp',
+                                        timeout: 250,
+                                        wait: false)
+    pid = @cmd.run!
+    assert_kind_of Fixnum, pid
+  end
 end

--- a/test/daemon_runner/shell_out_test.rb
+++ b/test/daemon_runner/shell_out_test.rb
@@ -74,4 +74,10 @@ class ShellOutTest < Minitest::Test
     pid = @cmd.run!
     assert_kind_of Fixnum, pid
   end
+
+  def test_returns_mixlib_shellout_for_wait
+    @cmd = ::TestShellOut.new
+    shellout = @cmd.run!
+    assert_kind_of Mixlib::ShellOut, shellout
+  end
 end


### PR DESCRIPTION
This fixes #15 so `DaemonRunner::Shellout#run!` now returns the pid of the spawned process when `wait: false` is provided in the constructor.