### PR TITLE
Feature: wait2

### DIFF
--- a/lib/daemon_runner/shell_out.rb
+++ b/lib/daemon_runner/shell_out.rb
@@ -40,6 +40,13 @@ module DaemonRunner
       end
     end
 
+    # Wait for the process to finish
+    # @param flags [Fixnum] flags to Process.wait2
+    # @return [Process::Status, nil] the process status or nil if no process was found
+    def wait2(flags = 0)
+      self.class.wait2(@pid, flags)
+    end
+
     private
 
     # Run a command and wait for it to finish
@@ -58,10 +65,10 @@ module DaemonRunner
     # @return [Fixnum] process id
     def run_and_detach
       log_r, log_w = IO.pipe
-      pid = Process.spawn(command, pgroup: true, err: :out, out: log_w)
+      @pid = Process.spawn(command, pgroup: true, err: :out, out: log_w)
       log_r.close
       log_w.close
-      pid
+      @pid
     end
 
     # Validate command is defined before trying to start the command

--- a/lib/daemon_runner/shell_out.rb
+++ b/lib/daemon_runner/shell_out.rb
@@ -10,6 +10,7 @@ module DaemonRunner
     # @param flags [Fixnum] flags to Process.wait2
     # @return [Process::Status, nil] the process status or nil if no process was found
     def self.wait2(pid = nil, flags = 0)
+      return nil if pid.nil?
       Process.wait2(pid, flags)[1]
     rescue Errno::ECHILD
       nil

--- a/lib/daemon_runner/shell_out.rb
+++ b/lib/daemon_runner/shell_out.rb
@@ -5,6 +5,16 @@ module DaemonRunner
     attr_reader :runner, :stdout
     attr_reader :command, :cwd, :timeout, :wait, :valid_exit_codes
 
+    # Wait for the process with the given pid to finish
+    # @param pid [Fixnum] the pid to wait on
+    # @param flags [Fixnum] flags to Process.wait2
+    # @return [Process::Status, nil] the process status or nil if no process was found
+    def self.wait2(pid = nil, flags = 0)
+      Process.wait2(pid, flags)[1]
+    rescue Errno::ECHILD
+      nil
+    end
+
     # @param command [String] the command to run
     # @param cwd [String] the working directory to run the command
     # @param timeout [Fixnum] the command timeout

--- a/test/daemon_runner/shell_out_test.rb
+++ b/test/daemon_runner/shell_out_test.rb
@@ -107,4 +107,13 @@ class ShellOutTest < Minitest::Test
     result = ::DaemonRunner::ShellOut.wait2
     assert_equal nil, result
   end
+
+  def test_wait2_tracks_running_process
+    @cmd = ::DaemonRunner::ShellOut.new(command: 'exit 255',
+                                        valid_exit_codes: [255],
+                                        wait: false)
+    @cmd.run!
+    result = @cmd.wait2
+    assert_equal 255, result.exitstatus
+  end
 end

--- a/test/daemon_runner/shell_out_test.rb
+++ b/test/daemon_runner/shell_out_test.rb
@@ -94,7 +94,7 @@ class ShellOutTest < Minitest::Test
     assert_equal [1], shellout.valid_exit_codes
   end
 
-  def test_returns_nil_if_waiting_without_child_process
+  def test_wait2_returns_nil_if_waiting_without_child_process
     wait2 = lambda { |pid, flags| raise Errno::ECHILD }
 
     Process.stub :wait2, wait2 do
@@ -103,7 +103,7 @@ class ShellOutTest < Minitest::Test
     end
   end
 
-  def test_returns_nil_if_pid_is_not_provided
+  def test_wait2_returns_nil_if_pid_is_not_provided
     result = ::DaemonRunner::ShellOut.wait2
     assert_equal nil, result
   end

--- a/test/daemon_runner/shell_out_test.rb
+++ b/test/daemon_runner/shell_out_test.rb
@@ -93,4 +93,13 @@ class ShellOutTest < Minitest::Test
     shellout = @cmd.run!
     assert_equal [1], shellout.valid_exit_codes
   end
+
+  def test_returns_nil_if_waiting_without_child_process
+    wait2 = lambda { |pid, flags| raise Errno::ECHILD }
+
+    Process.stub :wait2, wait2 do
+      result = ::DaemonRunner::ShellOut.wait2(2600)
+      assert_equal nil, result
+    end
+  end
 end

--- a/test/daemon_runner/shell_out_test.rb
+++ b/test/daemon_runner/shell_out_test.rb
@@ -116,4 +116,13 @@ class ShellOutTest < Minitest::Test
     result = @cmd.wait2
     assert_equal 255, result.exitstatus
   end
+
+  def test_wait2_returns_nil_if_running_process_is_waiting
+    @cmd = ::DaemonRunner::ShellOut.new(command: 'exit 255',
+                                        valid_exit_codes: [255],
+                                        wait: true)
+    @cmd.run!
+    result = @cmd.wait2
+    assert_equal nil, result
+  end
 end

--- a/test/daemon_runner/shell_out_test.rb
+++ b/test/daemon_runner/shell_out_test.rb
@@ -102,4 +102,9 @@ class ShellOutTest < Minitest::Test
       assert_equal nil, result
     end
   end
+
+  def test_returns_nil_if_pid_is_not_provided
+    result = ::DaemonRunner::ShellOut.wait2
+    assert_equal nil, result
+  end
 end


### PR DESCRIPTION
This fixes #18 by exposing a `wait2` method in `DaemonRunner::ShellOut`.