### PR TITLE
Move code to obtain session to class instance

### DIFF
--- a/test/daemon_runner/semaphore_test.rb
+++ b/test/daemon_runner/semaphore_test.rb
@@ -110,4 +110,13 @@ class SemaphoreTest < ConsulIntegrationTest
     @sem2.semaphore_state
     assert_equal lockfile, @sem2.lock_content
   end
+
+  def test_can_get_two_uniq_lock_sessions
+    @service1 = service_name
+    @service2 = service_name
+
+    @sem1 = DaemonRunner::Semaphore.start(@service1)
+    @sem2 = DaemonRunner::Semaphore.start(@service2)
+    refute_equal @sem1.session.id, @sem2.session.id
+  end
 end


### PR DESCRIPTION
This pull request changes the behavior of the class in that storage of the
lock is not handled in the class instance and not in an instance
variable at the class level.  This change should be mostly non-breaking.

The interaction with the code should remain mostly the same, you don't
have to call `start` before calling `lock`.  It behaves much closer to
the way `File` does in that `File.open`(without a block) returns an
instance a a class that you can do things with.  This now works in the
same way, from `lock` we return an instance of `Semaphore` so that you
can do what you need to do.

In addition to the above change, `renew` was extracted to make #22
easier to implement.

Fixes #23