### PR TITLE
Add mutex support

### DIFF
--- a/examples/example1.rb
+++ b/examples/example1.rb
@@ -37,11 +37,16 @@ class MyService
         end
 
         def run!(args)
+          sleep 10
           name = args[0]
           reason = args[1]
           puts name
           puts reason
           name
+        end
+
+        def task_id
+          'long-running-task'
         end
       end
     end
@@ -51,10 +56,13 @@ end
 class MyService
   class Tasks
     class Quiz
-      def schedule
-        [:interval, '30s']
+      def initialize
+        @task_id = 'long-running-task'
+        @schedule = [:interval, '30s']
       end
+
       def foo!(args)
+        sleep 10
         puts 'Firing error'
         sargs
       end

--- a/lib/daemon_runner/client.rb
+++ b/lib/daemon_runner/client.rb
@@ -21,12 +21,17 @@ module DaemonRunner
         logger = job[:logger]
         task_id = job[:task_id]
 
+        mutex = @mutexes[task_id]
+
         logger.error "#{task_id}: #{error}"
         logger.debug "#{task_id}: Suspending #{task_id} for #{error_sleep_time} seconds"
-        job.pause
+
+        # Unlock the job mutex if the job owns it and on_error_release_lock is true
+        mutex.unlock if on_error_release_lock && mutex.owned?
+
         sleep error_sleep_time
+
         logger.debug "#{task_id}: Resuming #{task_id}"
-        job.resume
       end
     end
 

--- a/lib/daemon_runner/client.rb
+++ b/lib/daemon_runner/client.rb
@@ -143,10 +143,12 @@ module DaemonRunner
     def parse_schedule(instance)
       valid_types = [:in, :at, :every, :interval, :cron]
       out = {}
-      task_schedule = if instance.respond_to?(:schedule)
-        instance.send(:schedule)
+      if instance.instance_variable_defined?(:@schedule)
+        task_schedule = instance.instance_variable_get(:@schedule)
+      elsif instance.respond_to?(:schedule)
+        task_schedule = instance.send(:schedule)
       else
-        schedule
+        task_schedule = schedule
       end
 
       raise ArgumentError, 'Malformed schedule definition, should be [TYPE, DURATION]' if task_schedule.length < 2


### PR DESCRIPTION
This PR adds support for preventing separate tasks from running at the same time.

Using a mutex does not replace the semaphore support. Instead it's supposed to prevent different, intensive tasks from executing at the same time and crushing the system.