### PR TITLE
Allow an optional block to be passed

### DIFF
--- a/examples/example_semaphore_release.rb
+++ b/examples/example_semaphore_release.rb
@@ -8,13 +8,9 @@ require 'dev/consul'
 @locked = false
 @lock_time = 10
 
-@semaphore = DaemonRunner::Semaphore.start(@service)
-lock = DaemonRunner::Semaphore.lock(@lock_count)
-
-@lock_time.downto(0).each do |i|
-  @semaphore.logger.info "Releasing lock in #{i} seconds"
-  sleep 1
+DaemonRunner::Semaphore.lock(@service, @lock_count) do
+  @lock_time.downto(0).each do |i|
+   puts "Releasing lock in #{i} seconds"
+   sleep 1
+  end
 end
-
-lock.join
-DaemonRunner::Semaphore.release

--- a/lib/daemon_runner/semaphore.rb
+++ b/lib/daemon_runner/semaphore.rb
@@ -15,9 +15,15 @@ module DaemonRunner
       #
       def lock(name, limit = 3, **options)
         options.merge!(name: name)
-        lock = Semaphore.new(options)
-        lock.lock
-        lock
+        semaphore = Semaphore.new(options)
+        semaphore.lock
+        if block_given?
+          lock_thr = semaphore.renew
+          yield
+          lock_thr.kill
+          semaphore.release
+        end
+        semaphore
       end
     end
 


### PR DESCRIPTION
This change allows an optional block to be passed to `lock`.  `lock` now
behaves very much the same as `File.open`, it now releases the lock at
the end of the block.

Fixes #22