### PR TITLE
Don't cache the Mixlib::ShellOut instance

### DIFF
--- a/lib/daemon_runner/shell_out.rb
+++ b/lib/daemon_runner/shell_out.rb
@@ -94,7 +94,7 @@ module DaemonRunner
     # Setup a new Mixlib::ShellOut client runner
     # @return [Mixlib::ShellOut] client
     def runner
-      @runner ||= Mixlib::ShellOut.new(command, :cwd => cwd, :timeout => timeout)
+      @runner = Mixlib::ShellOut.new(command, :cwd => cwd, :timeout => timeout)
       @runner.valid_exit_codes = valid_exit_codes
     end
   end


### PR DESCRIPTION
`Mixlib::Shellout` will reuse the pipes if you run a second command
using the same instance.

Thanks to @fmitchell-r7 for finding this!