### PR TITLE
Fix Semaphore.lock fails without block

### DIFF
--- a/README.md
+++ b/README.md
@@ -168,7 +168,7 @@ Locking can be done either via an exclusive lock or a semaphore lock.  The major
 **TBD**
 
 #### Semaphore Lock
-For an example of how to implement semaphore locking take a look at the [example](/examples/example_semaphore.rb)
+For an example of how to implement semaphore locking take a look at the [manual locking example](/examples/example_semaphore.rb) and the [slightly more automatic version](/examples/example_semaphore_release.rb).
 
 
 ## Development

--- a/examples/example_semaphore.rb
+++ b/examples/example_semaphore.rb
@@ -5,7 +5,7 @@ require 'dev/consul'
 
 @service = 'myservice'
 @lock_count = 3
-@locked = false
+@lock_time = 10
 
 ::Dev::Consul.run
 ::Dev::Consul.wait
@@ -17,8 +17,10 @@ require 'dev/consul'
 @renew_thread = @semaphore.renew
 
 # Do whatever kind of work you want
-puts 'Working...'
-sleep 1
+@lock_time.downto(0).each do |i|
+  puts "Releasing lock in #{i} seconds"
+  sleep 1
+end
 
 # Kill the thread when you're done
 @renew_thread.kill

--- a/examples/example_semaphore.rb
+++ b/examples/example_semaphore.rb
@@ -7,5 +7,23 @@ require 'dev/consul'
 @lock_count = 3
 @locked = false
 
-@semaphore = DaemonRunner::Semaphore.start(@service)
-DaemonRunner::Semaphore.lock(@lock_count)
+::Dev::Consul.run
+::Dev::Consul.wait
+
+# Get a new semaphore
+@semaphore = DaemonRunner::Semaphore.lock(@service, @lock_count)
+
+# Spawn a thread to handle renewing the lock
+@renew_thread = @semaphore.renew
+
+# Do whatever kind of work you want
+puts 'Working...'
+sleep 1
+
+# Kill the thread when you're done
+@renew_thread.kill
+
+# Explicitly release the semaphore when you're done
+@semaphore.release
+
+::Dev::Consul.stop

--- a/examples/example_semaphore_release.rb
+++ b/examples/example_semaphore_release.rb
@@ -5,8 +5,10 @@ require 'dev/consul'
 
 @service = 'myreleaseservice'
 @lock_count = 3
-@locked = false
 @lock_time = 10
+
+::Dev::Consul.run
+::Dev::Consul.wait
 
 DaemonRunner::Semaphore.lock(@service, @lock_count) do
   @lock_time.downto(0).each do |i|
@@ -14,3 +16,5 @@ DaemonRunner::Semaphore.lock(@service, @lock_count) do
    sleep 1
   end
 end
+
+::Dev::Consul.stop

--- a/lib/daemon_runner/semaphore.rb
+++ b/lib/daemon_runner/semaphore.rb
@@ -23,7 +23,7 @@ module DaemonRunner
             lock_thr = semaphore.renew
             yield
           ensure
-            lock_thr.kill
+            lock_thr.kill unless lock_thr.nil?
             semaphore.release
           end
         end

--- a/lib/daemon_runner/semaphore.rb
+++ b/lib/daemon_runner/semaphore.rb
@@ -19,17 +19,19 @@ module DaemonRunner
         semaphore = Semaphore.new(options)
         semaphore.lock
         if block_given?
-          lock_thr = semaphore.renew
-          yield
+          begin
+            lock_thr = semaphore.renew
+            yield
+          ensure
+            lock_thr.kill
+            semaphore.release
+          end
         end
         semaphore
       rescue Exception => e
         logger.error e
         logger.debug e.backtrace.join("\n")
         raise
-      ensure
-        lock_thr.kill unless lock_thr.nil?
-        semaphore.release
       end
     end
 

--- a/lib/daemon_runner/semaphore.rb
+++ b/lib/daemon_runner/semaphore.rb
@@ -28,7 +28,7 @@ module DaemonRunner
         logger.debug e.backtrace.join("\n")
         raise
       ensure
-        lock_thr.kill
+        lock_thr.kill unless lock_thr.nil?
         semaphore.release
       end
     end


### PR DESCRIPTION
This fixes #35. We no longer try to kill the renewal thread if it hasn't been spawned.