### PR TITLE
Fix: Set limit in Semaphore.lock

### DIFF
--- a/lib/daemon_runner/semaphore.rb
+++ b/lib/daemon_runner/semaphore.rb
@@ -16,6 +16,7 @@ module DaemonRunner
       #
       def lock(name, limit = 3, **options)
         options.merge!(name: name)
+        options.merge!(limit: limit)
         semaphore = Semaphore.new(options)
         semaphore.lock
         if block_given?

--- a/test/daemon_runner/semaphore_test.rb
+++ b/test/daemon_runner/semaphore_test.rb
@@ -112,6 +112,11 @@ class SemaphoreTest < ConsulIntegrationTest
     assert_equal 3, @sem.limit
   end
 
+  def test_semaphore_lock_with_custom_limit
+    @sem = DaemonRunner::Semaphore.lock(@service, 1)
+    assert_equal 1, @sem.limit
+  end
+
   def test_can_get_two_uniq_lock_sessions
     @service1 = service_name
     @service2 = service_name

--- a/test/daemon_runner/semaphore_test.rb
+++ b/test/daemon_runner/semaphore_test.rb
@@ -107,6 +107,11 @@ class SemaphoreTest < ConsulIntegrationTest
     assert_equal lockfile, @sem2.lock_content
   end
 
+  def test_semaphore_lock_with_default_limit
+    @sem = DaemonRunner::Semaphore.lock(@service)
+    assert_equal 3, @sem.limit
+  end
+
   def test_can_get_two_uniq_lock_sessions
     @service1 = service_name
     @service2 = service_name


### PR DESCRIPTION
This fixes #38 by passing the custom limit from `Semaphore.lock` on to the `Semaphore.new` call.