### PR TITLE
Feature: Check if semaphore locked

### DIFF
--- a/lib/daemon_runner/semaphore.rb
+++ b/lib/daemon_runner/semaphore.rb
@@ -81,6 +81,14 @@ module DaemonRunner
       try_lock
     end
 
+    # Check if the semaphore holds the lock
+    #
+    # @return [Boolean] `true` if the lock is held, `false` otherwise
+    def locked?
+      semaphore_state
+      lock_exists? && (lock_content['Holders'] || []).include?(session.id)
+    end
+
     # Renew lock watching for changes
     # @return [Thread] Thread running a blocking call maintaining the lock state
     #

--- a/test/daemon_runner/semaphore_test.rb
+++ b/test/daemon_runner/semaphore_test.rb
@@ -117,6 +117,20 @@ class SemaphoreTest < ConsulIntegrationTest
     assert_equal 1, @sem.limit
   end
 
+  def test_can_check_semaphore_locked_state
+    @sem1 = DaemonRunner::Semaphore.lock(@service, 1)
+    @sem2 = DaemonRunner::Semaphore.lock(@service, 1)
+
+    assert_equal true, @sem1.locked?
+    assert_equal false, @sem2.locked?
+
+    @sem1.release
+    @sem2.lock
+
+    assert_equal false, @sem1.locked?
+    assert_equal true, @sem2.locked?
+  end
+
   def test_can_get_two_uniq_lock_sessions
     @service1 = service_name
     @service2 = service_name


### PR DESCRIPTION
This fixes #26 by providing a `Semaphore#locked?` method for checking if the semaphore holds the lock.
```ruby
semaphore = Semaphore.lock('service', 1)
assert_equal true, semaphore.locked?

semaphore.release
assert_equal false, semaphore.locked?
```