### PR TITLE
Fix: Semaphore.lock waits to yield

### DIFF
--- a/lib/daemon_runner/semaphore.rb
+++ b/lib/daemon_runner/semaphore.rb
@@ -22,6 +22,7 @@ module DaemonRunner
         if block_given?
           begin
             lock_thr = semaphore.renew
+            loop until semaphore.locked?
             yield
           ensure
             lock_thr.kill unless lock_thr.nil?

--- a/lib/daemon_runner/semaphore.rb
+++ b/lib/daemon_runner/semaphore.rb
@@ -21,8 +21,11 @@ module DaemonRunner
         semaphore.lock
         if block_given?
           begin
+            until semaphore.locked?
+              semaphore.try_lock
+              sleep 0.1
+            end
             lock_thr = semaphore.renew
-            sleep 0.1 until semaphore.locked?
             yield
           ensure
             lock_thr.kill unless lock_thr.nil?

--- a/lib/daemon_runner/semaphore.rb
+++ b/lib/daemon_runner/semaphore.rb
@@ -22,7 +22,7 @@ module DaemonRunner
         if block_given?
           begin
             lock_thr = semaphore.renew
-            loop until semaphore.locked?
+            sleep 0.1 until semaphore.locked?
             yield
           ensure
             lock_thr.kill unless lock_thr.nil?

--- a/test/daemon_runner/semaphore_test.rb
+++ b/test/daemon_runner/semaphore_test.rb
@@ -42,6 +42,13 @@ class SemaphoreTest < ConsulIntegrationTest
     @session = @sem.session
   end
 
+  def teardown
+    super
+    ObjectSpace.each_object(DaemonRunner::Semaphore) do |semaphore|
+      semaphore.release
+    end
+  end
+
   def test_can_get_prefix
     assert_equal "service/#{@service}/lock/", @sem.prefix
   end

--- a/test/daemon_runner/semaphore_test.rb
+++ b/test/daemon_runner/semaphore_test.rb
@@ -36,12 +36,6 @@ class MockSemaphore
 end
 
 class SemaphoreTest < ConsulIntegrationTest
-  def setup
-    super
-    @sem = DaemonRunner::Semaphore.new(name: @service)
-    @session = @sem.session
-  end
-
   def teardown
     super
     ObjectSpace.each_object(DaemonRunner::Semaphore) do |semaphore|
@@ -50,6 +44,7 @@ class SemaphoreTest < ConsulIntegrationTest
   end
 
   def test_can_get_prefix
+    @sem = DaemonRunner::Semaphore.new(name: @service)
     assert_equal "service/#{@service}/lock/", @sem.prefix
   end
 
@@ -62,14 +57,17 @@ class SemaphoreTest < ConsulIntegrationTest
   end
 
   def test_can_write_contender_key
+    @sem = DaemonRunner::Semaphore.new(name: @service)
     assert @sem.contender_key
   end
 
   def test_can_get_empty_semapore_state
+    @sem = DaemonRunner::Semaphore.new(name: @service)
     assert_empty @sem.semaphore_state
   end
 
   def test_can_get_semapore_state
+    @sem = DaemonRunner::Semaphore.new(name: @service)
     @sem.contender_key
     refute_empty @sem.semaphore_state
     refute_nil @sem.state


### PR DESCRIPTION
This fixes #37. Calls to `Semaphore.lock` that are passed a block will now wait until the lock is acquired before yielding to the block.